### PR TITLE
fix game_name for space invaders

### DIFF
--- a/gym_minatar/envs/space_invaders.py
+++ b/gym_minatar/envs/space_invaders.py
@@ -8,7 +8,7 @@ from gym_minatar.envs.base import BaseEnv
 
 class SpaceInvadersEnv(BaseEnv):
   def __init__(self, display_time=50, **kwargs):
-    self.game_name = 'SpaceInvaders'
+    self.game_name = 'space_invaders'
     self.display_time = display_time
     self.init(**kwargs)
 


### PR DESCRIPTION
MinAtar game SpaceInvaders was not loadable, as the game_name has to be identical to the filename (space_invaders.py) for importlib to find it.